### PR TITLE
fix(token-usage): 将 Provider 排行改为饼图

### DIFF
--- a/apps/desktop/src/components/TokenUsageDashboard/index.tsx
+++ b/apps/desktop/src/components/TokenUsageDashboard/index.tsx
@@ -129,44 +129,6 @@ function aggregateEntries(entries: TokenUsageEntry[], label: (entry: TokenUsageE
   return [...totals.entries()].sort((left, right) => right[1] - left[1]).slice(0, MAX_RANKING_ITEMS);
 }
 
-function rankingOption(
-  data: Array<[string, number]>,
-  palette: ChartPalette,
-  language: Language,
-): EChartsOption {
-  const sorted = [...data].reverse();
-  return {
-    animationDurationUpdate: 280,
-    aria: { enabled: true },
-    tooltip: {
-      trigger: "axis",
-      axisPointer: { type: "shadow" },
-      valueFormatter: (value: unknown) => `${formatTokens(Number(value), language)} Tokens`,
-    },
-    grid: { left: 18, right: 26, top: 12, bottom: 16, containLabel: true },
-    xAxis: {
-      type: "value",
-      axisLabel: { color: palette.muted, formatter: (value: number) => formatTokens(value, language) },
-      splitLine: { lineStyle: { color: palette.grid } },
-    },
-    yAxis: {
-      type: "category",
-      data: sorted.map(([label]) => label),
-      axisLabel: { color: palette.text, width: 118, overflow: "truncate" },
-      axisTick: { show: false },
-      axisLine: { show: false },
-    },
-    series: [{
-      type: "bar",
-      data: sorted.map(([, value]) => value),
-      barMaxWidth: 14,
-      itemStyle: { color: palette.series[0], borderRadius: [0, 4, 4, 0] },
-      label: { show: true, position: "right", color: palette.muted,
-        formatter: (params: any) => formatTokens(Number(params.value), language) },
-    }],
-  };
-}
-
 function usagePieOption(
   data: Array<[string, number]>,
   palette: ChartPalette,
@@ -471,7 +433,7 @@ export function TokenUsageDashboard({
         </section>
         <section className={styles.tokenChartPanel}>
           <div className={styles.tokenChartHeading}><h2>{labels.providers}</h2><span>{labels.recent}</span></div>
-          <EChart option={rankingOption(providerData, palette, language)} label={labels.providers} />
+          <EChart option={usagePieOption(providerData, palette, language)} label={labels.providers} />
         </section>
         <section className={styles.tokenChartPanel}>
           <div className={styles.tokenChartHeading}><h2>{labels.models}</h2><span>{labels.recent}</span></div>


### PR DESCRIPTION
## 变更内容

- 将 Token 汇总中的 Provider 排行改为与模型消耗一致的环形饼图
- 复用现有 `usagePieOption`，移除不再使用的横向柱状图配置

## 影响范围

- 仅调整 Token Usage Dashboard 的前端可视化
- 不修改“排行基于最近 500 条代理请求”的查询上限、统计逻辑或数据来源
- 不涉及凭据、安全边界、数据存储位置或后端接口

## 验证

- `npm run check`（pre-commit Hook）：5 个 workspace 检查通过，后端 249 项测试通过
- `cargo test --locked`：423 项通过，3 项忽略，0 项失败
- `cargo fmt --check`：通过
- `cargo clippy --all-targets --locked`：通过
- 浏览器预览人工验收：Provider 显示为环形饼图，模型消耗显示保持不变，控制台无错误

## 变更前后

> 以下截图使用 500 条匿名演示请求，不包含真实账户信息。

### 变更前

![Provider 排行变更前](https://github.com/user-attachments/assets/8e66176c-2c57-4444-a02f-ac0cd635783f)

### 变更后

![Provider 排行变更后](https://github.com/user-attachments/assets/7ed13683-381e-486f-a5ca-7aad71ccabd9)

## 已知限制

无。