### PR TITLE
fix(desktop): 优化云端登录 Tab 顺序

### DIFF
--- a/apps/desktop/src/components/modals/CloudLoginModal.tsx
+++ b/apps/desktop/src/components/modals/CloudLoginModal.tsx
@@ -98,10 +98,7 @@ export function CloudLoginModal({
                 setEmail(event.target.value);
               }}
               placeholder={t("cloudLogin.emailPlaceholder")} /></span>
-          <div className="cloud-login-label-row">
-            <label htmlFor="cloud-login-password">{t("cloudLogin.password")}</label>
-            <button type="button" onClick={onForgotPassword}>{t("cloudLogin.forgotPassword")}</button>
-          </div>
+          <label htmlFor="cloud-login-password">{t("cloudLogin.password")}</label>
           <span className="cloud-login-input"><LockKeyhole size={16} />
             <input id="cloud-login-password" type="password" autoComplete="current-password" value={password}
               disabled={loading} onChange={(event) => {
@@ -109,17 +106,22 @@ export function CloudLoginModal({
                 setPassword(event.target.value);
               }}
               placeholder={t("cloudLogin.passwordPlaceholder")} /></span>
-          <label className="cloud-remember-password">
-            <input type="checkbox" checked={rememberPassword} disabled={loading}
-              onChange={(event) => {
-                credentialsEdited.current = true;
-                setRememberPassword(event.target.checked);
-              }} />
-            <span>
-              <b>{t("cloudLogin.rememberPassword")}</b>
-              <small>{t("cloudLogin.rememberPasswordHint")}</small>
-            </span>
-          </label>
+          <div className="cloud-login-options-row">
+            <label className="cloud-remember-password">
+              <input type="checkbox" checked={rememberPassword} disabled={loading}
+                onChange={(event) => {
+                  credentialsEdited.current = true;
+                  setRememberPassword(event.target.checked);
+                }} />
+              <span>
+                <b>{t("cloudLogin.rememberPassword")}</b>
+                <small>{t("cloudLogin.rememberPasswordHint")}</small>
+              </span>
+            </label>
+            <button type="button" className="cloud-forgot-password" onClick={onForgotPassword}>
+              {t("cloudLogin.forgotPassword")}
+            </button>
+          </div>
           {registerMode && <>
             <label htmlFor="cloud-registration-code">{t("cloudLogin.verificationCode")}</label>
             <div className="cloud-verification-row">

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -716,20 +716,20 @@ h1 { margin: 5px 0 0; font: 700 26px/1.1 Manrope, sans-serif; letter-spacing: -.
 .cloud-login-modal { width: min(430px, 95vw); }
 .cloud-login-form { display: grid; gap: 8px; }
 .cloud-login-form label { color: #526259; font-size: 11px; font-weight: 700; }
-.cloud-login-label-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.cloud-login-label-row button { border: 0; padding: 0; color: var(--green-dark); background: transparent; font-size: 11px; cursor: pointer; }
-.cloud-login-label-row button:hover { text-decoration: underline; }
 .cloud-session-expired { display: flex; align-items: flex-start; gap: 8px; margin: 10px 0 12px; padding: 10px 11px; border: 1px solid #e8c6a4; border-radius: 9px; color: #7d481e; background: #fff7ed; font-size: 11px; line-height: 1.5; }
 .cloud-session-expired > svg { flex: 0 0 auto; margin-top: 1px; }
 .cloud-login-input { height: 39px; display: flex; align-items: center; gap: 8px; padding: 0 11px; border: 1px solid #d7e0d8; border-radius: 9px; color: #6d7a72; background: white; }
 .cloud-login-input:focus-within { border-color: var(--green); box-shadow: 0 0 0 3px rgba(var(--green-rgb), .12); }
 .cloud-login-input input { width: 100%; min-width: 0; border: 0; outline: 0; color: var(--ink); background: transparent; font: 12px "DM Sans", "Microsoft YaHei UI", sans-serif; }
 .cloud-login-input input::placeholder { color: #9aa69f; }
+.cloud-login-options-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .cloud-login-form .cloud-remember-password { display: flex; align-items: flex-start; gap: 8px; padding: 3px 1px 1px; cursor: pointer; }
 .cloud-remember-password input { width: 14px; height: 14px; margin: 1px 0 0; accent-color: var(--green); }
 .cloud-remember-password span { display: grid; gap: 2px; }
 .cloud-remember-password b { color: #526259; font-size: 11px; }
 .cloud-remember-password small { color: #88948d; font-size: 9px; font-weight: 400; line-height: 1.4; }
+.cloud-forgot-password { flex: 0 0 auto; border: 0; padding: 3px 0 0; color: var(--green-dark); background: transparent; font-size: 11px; cursor: pointer; }
+.cloud-forgot-password:hover { text-decoration: underline; }
 .cloud-verification-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; }
 .cloud-code-button { min-width: 104px; border: 1px solid rgba(var(--green-rgb), .35); border-radius: 9px; padding: 0 12px; color: var(--green-dark); background: #f6fbf7; font-size: 11px; font-weight: 600; cursor: pointer; }
 .cloud-code-button:hover:not(:disabled) { border-color: var(--green); background: #edf7ef; }


### PR DESCRIPTION
## 变更说明

- 将“忘记密码”移动到“记住密码”同一行的右侧。
- 保持邮箱、密码、记住密码、忘记密码的自然键盘焦点顺序，符合常见输入习惯。

## 界面对比

### 变更前

<img width="431" height="425" alt="云端登录界面（变更前）" src="https://github.com/user-attachments/assets/c1da5f03-2d25-42ea-9c55-16981d8c2b1c" />

### 变更后

<img width="430" height="422" alt="云端登录界面（变更后）" src="https://github.com/user-attachments/assets/40f798f5-b3a8-4bc3-9d9e-8a5d273105bb" />

## 验证

- 浏览器预览人工验收通过。
- npm run check 的前端、后端和 TypeScript 检查通过。
- Rust 格式检查与 424 项测试通过，另有 3 项按项目配置忽略。

## 影响

- 仅调整桌面端云端登录表单布局与样式。
- 不涉及凭据存储、认证逻辑或 IPC 接口。