### PR TITLE
fix(desktop): 避免 Provider I/O 阻塞 Windows 界面线程

### DIFF
--- a/apps/desktop/src-tauri/src/providers/provider_commands.rs
+++ b/apps/desktop/src-tauri/src/providers/provider_commands.rs
@@ -1,5 +1,13 @@
 #[tauri::command]
-pub(crate) fn list_providers<R: Runtime>(
+pub(crate) async fn list_providers<R: Runtime + 'static>(
+    app: tauri::AppHandle<R>,
+) -> Result<Vec<ProviderSummary>, String> {
+    tauri::async_runtime::spawn_blocking(move || list_providers_blocking(app))
+        .await
+        .map_err(|error| format!("Provider list task failed: {error}"))?
+}
+
+pub(crate) fn list_providers_blocking<R: Runtime>(
     app: tauri::AppHandle<R>,
 ) -> Result<Vec<ProviderSummary>, String> {
     let paths = resolve_paths(&app)?;

--- a/apps/desktop/src-tauri/src/system_tray.rs
+++ b/apps/desktop/src-tauri/src/system_tray.rs
@@ -11,6 +11,10 @@ use crate::{
     storage::read_app_settings,
 };
 
+mod refresh;
+
+pub(crate) use refresh::refresh_menu;
+
 const TRAY_ID: &str = "main-tray";
 const DASHBOARD_ID: &str = "tray:dashboard";
 const SETTINGS_ID: &str = "tray:settings";
@@ -26,7 +30,7 @@ const MENU_EMAIL_CHARS: usize = 15;
 const MENU_PROVIDER_CHARS: usize = 28;
 
 pub(crate) fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
-    let menu = build_menu(app.handle())?;
+    let menu = build_initial_menu(app.handle())?;
     let mut builder = TrayIconBuilder::with_id(TRAY_ID)
         .menu(&menu)
         .tooltip("Codex Switch")
@@ -49,21 +53,36 @@ pub(crate) fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     builder.build(app)?;
+    refresh_menu(app.handle());
     Ok(())
 }
 
-pub(crate) fn refresh_menu<R: Runtime>(app: &AppHandle<R>) {
-    let Some(tray) = app.tray_by_id(TRAY_ID) else {
-        return;
-    };
-    match build_menu(app) {
-        Ok(menu) => {
-            if let Err(error) = tray.set_menu(Some(menu)) {
-                eprintln!("failed to refresh tray menu: {error}");
-            }
-        }
-        Err(error) => eprintln!("failed to build tray menu: {error}"),
-    }
+fn build_initial_menu<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<Menu<R>, Box<dyn std::error::Error>> {
+    let menu = Menu::new(app)?;
+    menu.append(&MenuItem::with_id(
+        app,
+        DASHBOARD_ID,
+        "Dashboard",
+        true,
+        None::<&str>,
+    )?)?;
+    menu.append(&MenuItem::with_id(
+        app,
+        "tray:loading",
+        "正在加载…",
+        false,
+        None::<&str>,
+    )?)?;
+    menu.append(&MenuItem::with_id(
+        app,
+        QUIT_ID,
+        "Quit",
+        true,
+        None::<&str>,
+    )?)?;
+    Ok(menu)
 }
 
 pub(crate) fn show_dashboard<R: Runtime>(app: &AppHandle<R>) {
@@ -266,7 +285,7 @@ fn append_provider_items<R: Runtime>(
     )?;
     menu.append(&header)?;
 
-    match providers::list_providers(app.clone()) {
+    match providers::list_providers_blocking(app.clone()) {
         Ok(providers) => {
             if providers.is_empty() {
                 let empty = MenuItem::with_id(

--- a/apps/desktop/src-tauri/src/system_tray/refresh.rs
+++ b/apps/desktop/src-tauri/src/system_tray/refresh.rs
@@ -1,0 +1,113 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use tauri::{AppHandle, Runtime};
+
+use super::{build_menu, TRAY_ID};
+
+const REFRESH_IDLE: u8 = 0;
+const REFRESH_RUNNING: u8 = 1;
+const REFRESH_PENDING: u8 = 2;
+
+static TRAY_REFRESH_GATE: TrayRefreshGate = TrayRefreshGate::new();
+
+pub(crate) fn refresh_menu<R: Runtime + 'static>(app: &AppHandle<R>) {
+    if !TRAY_REFRESH_GATE.request() {
+        return;
+    }
+
+    let menu_app = app.clone();
+    tauri::async_runtime::spawn_blocking(move || loop {
+        refresh_menu_once(&menu_app);
+        if !TRAY_REFRESH_GATE.finish_iteration() {
+            break;
+        }
+    });
+}
+
+fn refresh_menu_once<R: Runtime>(app: &AppHandle<R>) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+    match build_menu(app) {
+        Ok(menu) => {
+            if let Err(error) = tray.set_menu(Some(menu)) {
+                eprintln!("failed to refresh tray menu: {error}");
+            }
+        }
+        Err(error) => eprintln!("failed to build tray menu: {error}"),
+    }
+}
+
+struct TrayRefreshGate {
+    state: AtomicU8,
+}
+
+impl TrayRefreshGate {
+    const fn new() -> Self {
+        Self {
+            state: AtomicU8::new(REFRESH_IDLE),
+        }
+    }
+
+    fn request(&self) -> bool {
+        loop {
+            let current = self.state.load(Ordering::Acquire);
+            let (next, should_start_worker) = match current {
+                REFRESH_IDLE => (REFRESH_RUNNING, true),
+                REFRESH_RUNNING => (REFRESH_PENDING, false),
+                REFRESH_PENDING => return false,
+                _ => return false,
+            };
+            if self
+                .state
+                .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return should_start_worker;
+            }
+        }
+    }
+
+    fn finish_iteration(&self) -> bool {
+        loop {
+            let current = self.state.load(Ordering::Acquire);
+            let (next, should_rerun) = match current {
+                REFRESH_RUNNING => (REFRESH_IDLE, false),
+                REFRESH_PENDING => (REFRESH_RUNNING, true),
+                _ => return false,
+            };
+            if self
+                .state
+                .compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return should_rerun;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TrayRefreshGate;
+
+    #[test]
+    fn refresh_requests_are_coalesced_while_a_worker_is_running() {
+        let gate = TrayRefreshGate::new();
+
+        assert!(gate.request());
+        assert!(!gate.request());
+        assert!(!gate.request());
+        assert!(gate.finish_iteration());
+        assert!(!gate.finish_iteration());
+    }
+
+    #[test]
+    fn refresh_gate_returns_to_idle_after_the_worker_finishes() {
+        let gate = TrayRefreshGate::new();
+
+        assert!(gate.request());
+        assert!(!gate.finish_iteration());
+        assert!(gate.request());
+    }
+}

--- a/apps/desktop/src-tauri/src/web_server/dispatch_primary.rs
+++ b/apps/desktop/src-tauri/src/web_server/dispatch_primary.rs
@@ -51,7 +51,7 @@ fn dispatch_command(app: AppHandle, command: &str, args: Value) -> Result<Value,
             argument(&args, "settings")?,
         ))),
         "list_aggregate_apis" => serialize(block_on(crate::aggregate_api::list_aggregate_apis(app))),
-        "list_providers" => serialize(crate::providers::list_providers(app)),
+        "list_providers" => serialize(block_on(crate::providers::list_providers(app))),
         "save_provider" => serialize(crate::providers::save_provider(
             app,
             argument(&args, "provider")?,


### PR DESCRIPTION
## 背景

桌面端启动时会读取本地 Provider 配置。变更前，Provider 目录枚举、文件读取和 JSON 解析均由同步 Tauri command 执行，系统托盘初始化也会同步执行相同操作。

在 Provider 文件较多、文件异常膨胀、磁盘响应较慢或文件受到安全软件扫描时，这些同步 I/O 可能阻塞 Windows 界面线程，导致窗口首帧白屏或短暂无响应。

一般只有少量 Provider 时，修复前后的性能差异通常不明显。本次修改主要用于消除潜在的界面线程阻塞，提高异常和高负载场景下的稳定性。

## 修改内容

- 将 `list_providers` 改为异步 Tauri command。
- 使用 blocking worker 执行 Provider 目录枚举、文件读取和 JSON 解析。
- 调整 Web/Headless 兼容层，等待异步 Provider 查询结果。
- 系统托盘启动时先显示轻量占位菜单。
- 在后台构建和刷新完整托盘菜单，避免阻塞界面线程。
- 为托盘刷新增加 single-flight 和请求合并：
  - 同一时间只允许一个菜单构建任务运行。
  - 运行期间的多个刷新请求合并为一次后续刷新。
  - 后续刷新重新读取最新状态，避免旧快照覆盖新菜单。

## 复现方式

使用独立测试配置生成 3,000 个合法 Provider 文件，每个文件约 256 KiB，总大小约 788 MB。

文件只包含合成测试数据，不包含真实账号或凭据。该负载用于稳定放大同步 I/O 阻塞，便于捕获变更前后的首帧差异。

## 测试结果

### 变更前

- 隔离窗口约 59 ms 后被发现。
- 首次截图请求耗时约 1,342 ms。
- 从开始采样到截图完成约 1,427 ms。
- 捕获到的首帧为完整白屏。

### 变更后

- 隔离窗口约 67 ms 后被发现。
- 首次截图请求耗时约 298 ms。
- 从开始采样到截图完成约 392 ms。
- 首帧已经完整渲染，未再捕获到白屏。

## 截图

### 变更前：窗口首帧白屏

![变更前：窗口首帧白屏](https://raw.githubusercontent.com/TorbenXiong/codex-switch/6b86a9f593047c1b17197ef0c06ba2259889fbbc/.pr-evidence/async-provider-listing/before.png)

### 变更后：窗口首帧正常渲染

![变更后：窗口首帧正常渲染](https://raw.githubusercontent.com/TorbenXiong/codex-switch/6b86a9f593047c1b17197ef0c06ba2259889fbbc/.pr-evidence/async-provider-listing/after.png)

## 验证

- [x] `cargo fmt --check`
- [x] 托盘刷新协调测试：4 通过
- [x] Rust 全量测试：428 通过，3 ignored
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] 桌面 TypeScript/Vite 生产构建
- [x] Windows 隔离环境高负载首帧复测

## 影响范围

本次修改针对 Provider 同步 I/O 导致的界面线程阻塞，不代表已经解决所有可能由 WebView 或窗口生命周期引起的本地白屏问题。
