### PR TITLE
fix: 修复官方代理瞬时连接失败与错误分类

### DIFF
--- a/apps/desktop/src-tauri/src/local_proxy/anthropic_forwarding.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/anthropic_forwarding.rs
@@ -37,7 +37,7 @@ fn forward_anthropic_official<R: tauri::Runtime>(
     _headers: &[(String, String)],
     body: Vec<u8>,
     session_id: Option<&str>,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let client = http_client()?;
     let credentials = official_credentials(
         app,
@@ -83,7 +83,7 @@ fn forward_anthropic_provider(
     body: Vec<u8>,
     provider: &ProviderProfile,
     subagent_model: &str,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let request: Value = serde_json::from_slice(&body)
         .map_err(|error| format!("Anthropic request body is not valid JSON: {error}"))?;
     let stream = request
@@ -124,7 +124,7 @@ fn convert_responses_payload(
     mut payload: UpstreamPayload,
     stream: bool,
     model: &str,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     if !status_ok(payload.status) {
         return Ok(payload);
     }

--- a/apps/desktop/src-tauri/src/local_proxy/auth_http.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/auth_http.rs
@@ -84,6 +84,53 @@ fn http_client() -> Result<Client, String> {
         .map_err(|error| format!("Failed to create proxy HTTP client: {error}"))
 }
 
+fn format_upstream_request_error(label: &str, error: &reqwest::Error) -> String {
+    let kind = reqwest_error_kind(error);
+    let chain = error_chain(error);
+    format!("{label} [{kind}]: {chain}")
+}
+
+fn reqwest_error_kind(error: &reqwest::Error) -> &'static str {
+    if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connect"
+    } else if error.is_request() {
+        "request"
+    } else {
+        "other"
+    }
+}
+
+fn error_chain(error: &(dyn Error + 'static)) -> String {
+    const MAX_CAUSES: usize = 4;
+    let mut parts = Vec::with_capacity(MAX_CAUSES);
+    let mut current = Some(error);
+    while let Some(error) = current {
+        parts.push(error.to_string());
+        if parts.len() == MAX_CAUSES {
+            break;
+        }
+        current = error.source();
+    }
+    parts.join("; cause: ")
+}
+
+fn upstream_error_kind(message: &str) -> Option<&'static str> {
+    ["timeout", "connect", "request", "other"]
+        .into_iter()
+        .find(|kind| message.contains(&format!("[{kind}]")))
+}
+
+fn upstream_error_status(message: &str) -> u16 {
+    match upstream_error_kind(message) {
+        Some("timeout") => 504,
+        Some("connect") => 503,
+        Some("request") | Some("other") => 502,
+        _ => 502,
+    }
+}
+
 fn reqwest_method(method: &Method) -> Result<reqwest::Method, String> {
     reqwest::Method::from_bytes(method.as_str().as_bytes())
         .map_err(|error| format!("Unsupported HTTP method {}: {error}", method.as_str()))

--- a/apps/desktop/src-tauri/src/local_proxy/auth_http.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/auth_http.rs
@@ -84,21 +84,21 @@ fn http_client() -> Result<Client, String> {
         .map_err(|error| format!("Failed to create proxy HTTP client: {error}"))
 }
 
-fn format_upstream_request_error(label: &str, error: &reqwest::Error) -> String {
-    let kind = reqwest_error_kind(error);
-    let chain = error_chain(error);
-    format!("{label} [{kind}]: {chain}")
+fn upstream_request_error(label: &'static str, error: reqwest::Error) -> UpstreamError {
+    let kind = reqwest_error_kind(&error);
+    let error = error.without_url();
+    UpstreamError::transport(kind, label, error_chain(&error))
 }
 
-fn reqwest_error_kind(error: &reqwest::Error) -> &'static str {
+fn reqwest_error_kind(error: &reqwest::Error) -> UpstreamTransportErrorKind {
     if error.is_timeout() {
-        "timeout"
+        UpstreamTransportErrorKind::Timeout
     } else if error.is_connect() {
-        "connect"
+        UpstreamTransportErrorKind::Connect
     } else if error.is_request() {
-        "request"
+        UpstreamTransportErrorKind::Request
     } else {
-        "other"
+        UpstreamTransportErrorKind::Other
     }
 }
 
@@ -116,27 +116,12 @@ fn error_chain(error: &(dyn Error + 'static)) -> String {
     parts.join("; cause: ")
 }
 
-fn upstream_error_kind(message: &str) -> Option<&'static str> {
-    ["timeout", "connect", "request", "other"]
-        .into_iter()
-        .find(|kind| message.contains(&format!("[{kind}]")))
-}
-
-fn upstream_error_status(message: &str) -> u16 {
-    match upstream_error_kind(message) {
-        Some("timeout") => 504,
-        Some("connect") => 503,
-        Some("request") | Some("other") => 502,
-        _ => 502,
-    }
-}
-
 fn reqwest_method(method: &Method) -> Result<reqwest::Method, String> {
     reqwest::Method::from_bytes(method.as_str().as_bytes())
         .map_err(|error| format!("Unsupported HTTP method {}: {error}", method.as_str()))
 }
 
-fn stream_response(response: ReqwestResponse) -> Result<UpstreamPayload, String> {
+fn stream_response(response: ReqwestResponse) -> UpstreamResult {
     let status = response.status().as_u16();
     let content_type = response
         .headers()

--- a/apps/desktop/src-tauri/src/local_proxy/capture.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/capture.rs
@@ -1,8 +1,8 @@
 fn attach_token_usage_capture<R: Runtime + 'static>(
     app: &tauri::AppHandle<R>,
     context: Option<TokenUsageContext>,
-    result: Result<UpstreamPayload, String>,
-) -> Result<UpstreamPayload, String> {
+    result: UpstreamResult,
+) -> UpstreamResult {
     let mut payload = result?;
     let Some(mut context) = context else {
         return Ok(payload);

--- a/apps/desktop/src-tauri/src/local_proxy/chat_bridge.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/chat_bridge.rs
@@ -4,9 +4,9 @@ fn forward_chat_bridge(
     headers: &[(String, String)],
     body: Vec<u8>,
     provider: &ProviderProfile,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     if *method != Method::Post {
-        return Err("Chat bridge only supports POST requests".to_string());
+        return Err("Chat bridge only supports POST requests".to_string().into());
     }
     let mut responses_body: Value = serde_json::from_slice(&body)
         .map_err(|error| format!("Responses request body is not valid JSON: {error}"))?;
@@ -43,7 +43,7 @@ fn forward_chat_bridge(
     let request = apply_forward_headers(request, headers, true);
     let response = request
         .send()
-        .map_err(|error| format!("Chat bridge request failed: {error}"))?;
+        .map_err(|error| upstream_request_error("Chat bridge request failed", error))?;
     let status = response.status().as_u16();
     let content_type = response
         .headers()
@@ -68,7 +68,7 @@ fn forward_chat_bridge(
 
     let body = response
         .bytes()
-        .map_err(|error| format!("Failed to read chat bridge response: {error}"))?;
+        .map_err(|error| upstream_request_error("Failed to read chat bridge response", error))?;
     if !status_ok(status) {
         return Ok(UpstreamPayload {
             status,

--- a/apps/desktop/src-tauri/src/local_proxy/constants.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/constants.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     error::Error,
+    fmt,
     fs::{self, OpenOptions},
     io::{self, BufRead, BufReader, Read, Write},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpStream},

--- a/apps/desktop/src-tauri/src/local_proxy/constants.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/constants.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    error::Error,
     fs::{self, OpenOptions},
     io::{self, BufRead, BufReader, Read, Write},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpStream},
@@ -58,6 +59,7 @@ use crate::{
 const OFFICIAL_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(600);
 const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+const MAX_UPSTREAM_TRANSPORT_RETRIES: u8 = 2;
 const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
 const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
 const CHAT_TOOL_NAME_MAX_LEN: usize = 64;

--- a/apps/desktop/src-tauri/src/local_proxy/forwarding.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/forwarding.rs
@@ -6,7 +6,7 @@ fn forward_official<R: Runtime>(
     body: Vec<u8>,
     model: &str,
     session_id: Option<&str>,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let client = http_client()?;
     let upstream_endpoint = upstream_endpoint_for_codex_request(url);
     let credential_purpose = if is_image_generation_endpoint(request_path(&upstream_endpoint)) {
@@ -49,7 +49,7 @@ fn send_official_request(
     headers: &[(String, String)],
     body: &[u8],
     authentication: &OfficialRequestAuthentication,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let mut request = client
         .request(reqwest_method(method)?, upstream_url)
         .header("originator", ORIGINATOR)
@@ -80,9 +80,7 @@ fn send_official_request(
         apply_forward_headers(request, headers, true)
             .body(body.to_vec())
             .send()
-            .map_err(|error| {
-                format_upstream_request_error("Official Codex proxy request failed", &error)
-            })?,
+            .map_err(|error| upstream_request_error("Official Codex proxy request failed", error))?,
     )
 }
 
@@ -122,7 +120,7 @@ fn forward_provider(
     headers: &[(String, String)],
     body: Vec<u8>,
     provider: &ProviderProfile,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let client = http_client()?;
     let upstream_endpoint = upstream_endpoint_for_codex_request(url);
     let upstream_url = build_upstream_url(&provider.base_url, &upstream_endpoint);
@@ -138,7 +136,7 @@ fn forward_provider(
         request
             .body(body)
             .send()
-            .map_err(|error| format_upstream_request_error("Provider proxy request failed", &error))?,
+            .map_err(|error| upstream_request_error("Provider proxy request failed", error))?,
     )
 }
 
@@ -148,7 +146,7 @@ fn forward_provider_request(
     headers: &[(String, String)],
     body: Vec<u8>,
     provider: &ProviderProfile,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     if provider.kind == ProviderKind::Custom
         && *method == Method::Post
         && is_response_create_endpoint(request_path(url))
@@ -165,7 +163,7 @@ fn forward_provider_request(
 
 fn forward_aggregate_request(
     request: AggregateForwardRequest<'_>,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let member_ids = request
         .target
         .profiles
@@ -182,7 +180,7 @@ fn forward_aggregate_request(
             &excluded,
         ) {
             Ok(member_id) => member_id,
-            Err(error) => return last_result.unwrap_or(Err(error)),
+            Err(error) => return last_result.unwrap_or_else(|| Err(error.into())),
         };
         let provider = request
             .target
@@ -212,25 +210,27 @@ fn forward_aggregate_request(
     }
 }
 
-fn aggregate_result_is_retryable(result: &Result<UpstreamPayload, String>) -> bool {
+fn aggregate_result_is_retryable(result: &UpstreamResult) -> bool {
     match result {
         Ok(payload) => matches!(payload.status, 408 | 425 | 429 | 500 | 502 | 503 | 504),
-        Err(error) => {
-            let error = error.to_ascii_lowercase();
-            [
-                "request failed",
-                "timed out",
-                "timeout",
-                "connection",
-                "connect error",
-                "network",
-                "dns",
-                "error sending request",
-            ]
-            .iter()
-            .any(|marker| error.contains(marker))
-        }
+        Err(error) => error.is_aggregate_retryable(),
     }
+}
+
+fn aggregate_error_message_is_retryable(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    [
+        "request failed",
+        "timed out",
+        "timeout",
+        "connection",
+        "connect error",
+        "network",
+        "dns",
+        "error sending request",
+    ]
+    .iter()
+    .any(|marker| message.contains(marker))
 }
 
 fn forward_provider_with_api_fallback(
@@ -239,7 +239,7 @@ fn forward_provider_with_api_fallback(
     headers: &[(String, String)],
     body: Vec<u8>,
     provider: &ProviderProfile,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let model = provider_request_model(&body, provider);
     if let Some(format) = provider.model_api_formats.get(&model).copied() {
         provider_api_cache::forget_format(&provider.id, &model);
@@ -274,7 +274,7 @@ fn forward_provider_with_format(
     headers: &[(String, String)],
     body: Vec<u8>,
     provider: &ProviderProfile,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     match format {
         ProviderApiFormat::OpenaiResponses => {
             forward_provider(method, url, headers, body, provider)
@@ -297,7 +297,7 @@ fn alternate_api_format(format: ProviderApiFormat) -> ProviderApiFormat {
     }
 }
 
-fn api_attempt_succeeded(result: &Result<UpstreamPayload, String>) -> bool {
+fn api_attempt_succeeded(result: &UpstreamResult) -> bool {
     result
         .as_ref()
         .is_ok_and(|payload| status_ok(payload.status))
@@ -312,14 +312,14 @@ fn remember_provider_api_format(
 }
 
 fn preferred_protocol_failure(
-    first: Result<UpstreamPayload, String>,
-    second: Result<UpstreamPayload, String>,
-) -> Result<UpstreamPayload, String> {
+    first: UpstreamResult,
+    second: UpstreamResult,
+) -> UpstreamResult {
     match (first, second) {
         (_, Ok(payload)) => Ok(payload),
         (Ok(payload), Err(_)) => Ok(payload),
-        (Err(first_error), Err(second_error)) => Err(format!(
+        (Err(first_error), Err(second_error)) => Err(UpstreamError::Other(format!(
             "Provider request failed for both supported API formats: {first_error}; {second_error}"
-        )),
+        ))),
     }
 }

--- a/apps/desktop/src-tauri/src/local_proxy/forwarding.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/forwarding.rs
@@ -80,7 +80,9 @@ fn send_official_request(
         apply_forward_headers(request, headers, true)
             .body(body.to_vec())
             .send()
-            .map_err(|error| format!("Official Codex proxy request failed: {error}"))?,
+            .map_err(|error| {
+                format_upstream_request_error("Official Codex proxy request failed", &error)
+            })?,
     )
 }
 
@@ -136,7 +138,7 @@ fn forward_provider(
         request
             .body(body)
             .send()
-            .map_err(|error| format!("Provider proxy request failed: {error}"))?,
+            .map_err(|error| format_upstream_request_error("Provider proxy request failed", &error))?,
     )
 }
 

--- a/apps/desktop/src-tauri/src/local_proxy/models.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/models.rs
@@ -3,7 +3,7 @@ fn models_payload<R: Runtime>(
     url: &str,
     headers: &[(String, String)],
     target: &ActiveTarget,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let upstream_headers = unconditional_model_catalog_headers(headers);
     let image_input_route_enabled = image_input_route_enabled(app);
     let payload = match target {
@@ -32,12 +32,14 @@ fn models_payload<R: Runtime>(
             ));
         }
         ActiveTarget::Aggregate(target) => {
-            return aggregate_models_payload(target, image_input_route_enabled);
+            return aggregate_models_payload(target, image_input_route_enabled)
+                .map_err(UpstreamError::from);
         }
     };
     let payload = override_model_image_input(payload, image_input_route_enabled)?;
     let context_window = read_app_settings(app)?.gpt_5_6_sol_context_window;
     override_model_context_window(payload, GPT_5_6_SOL_MODEL, context_window)
+        .map_err(UpstreamError::from)
 }
 
 fn image_input_route_enabled<R: Runtime>(app: &tauri::AppHandle<R>) -> bool {

--- a/apps/desktop/src-tauri/src/local_proxy/routing_target.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/routing_target.rs
@@ -83,8 +83,12 @@ fn image_model_target_for_request(
 fn request_contains_input_image(body: &[u8]) -> bool {
     serde_json::from_slice::<Value>(body)
         .ok()
-        .and_then(|value| value.get("input").cloned())
-        .is_some_and(|input| contains_input_image(&input))
+        .as_ref()
+        .is_some_and(parsed_request_contains_input_image)
+}
+
+fn parsed_request_contains_input_image(body: &Value) -> bool {
+    body.get("input").is_some_and(contains_input_image)
 }
 
 fn apply_image_output_model<R: Runtime>(
@@ -167,7 +171,9 @@ fn proxy_diagnostic_entry(
         "query": request_query_diagnostic(url),
         "upstreamEndpoint": request_path(&upstream_endpoint),
         "isResponsesEndpoint": is_responses_endpoint(path),
-        "containsInputImage": request_contains_input_image(body),
+        "containsInputImage": request_body
+            .as_ref()
+            .is_some_and(parsed_request_contains_input_image),
         "route": route.as_str(),
         "requestBodyBytes": body.len(),
         "requestBodyHash": short_hash_bytes(body),
@@ -189,7 +195,7 @@ fn proxy_diagnostic_entry(
 fn append_proxy_diagnostic_result<R: Runtime>(
     app: &tauri::AppHandle<R>,
     mut entry: Value,
-    result: &Result<UpstreamPayload, String>,
+    result: &UpstreamResult,
     duration: Duration,
 ) {
     entry["durationMs"] = json!(duration.as_millis() as u64);
@@ -218,11 +224,12 @@ fn append_proxy_diagnostic_result<R: Runtime>(
             entry["result"] = result;
         }
         Err(error) => {
+            let diagnostic_message = error.diagnostic_message();
             entry["result"] = json!({
                 "ok": false,
-                "errorKind": upstream_error_kind(error),
-                "error": truncate_for_log(error, 240),
-                "errorHash": short_hash_str(error)
+                "errorKind": error.kind(),
+                "error": truncate_for_log(&diagnostic_message, 240),
+                "errorHash": short_hash_str(&diagnostic_message)
             });
         }
     }

--- a/apps/desktop/src-tauri/src/local_proxy/routing_target.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/routing_target.rs
@@ -167,6 +167,7 @@ fn proxy_diagnostic_entry(
         "query": request_query_diagnostic(url),
         "upstreamEndpoint": request_path(&upstream_endpoint),
         "isResponsesEndpoint": is_responses_endpoint(path),
+        "containsInputImage": request_contains_input_image(body),
         "route": route.as_str(),
         "requestBodyBytes": body.len(),
         "requestBodyHash": short_hash_bytes(body),
@@ -219,6 +220,7 @@ fn append_proxy_diagnostic_result<R: Runtime>(
         Err(error) => {
             entry["result"] = json!({
                 "ok": false,
+                "errorKind": upstream_error_kind(error),
                 "error": truncate_for_log(error, 240),
                 "errorHash": short_hash_str(error)
             });

--- a/apps/desktop/src-tauri/src/local_proxy/server.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/server.rs
@@ -206,7 +206,10 @@ fn handle_request<R: Runtime>(app: tauri::AppHandle<R>, mut request: Request) {
     );
     let payload = match result {
         Ok(payload) => payload,
-        Err(error) => json_payload(502, json!({ "error": { "message": error } })),
+        Err(error) => json_payload(
+            upstream_error_status(&error),
+            json!({ "error": { "message": error } }),
+        ),
     };
     respond_payload(
         request,
@@ -554,9 +557,21 @@ where
     W: FnMut(Duration) -> Duration,
 {
     let mut retry_number = 0_u16;
+    let mut transport_retry_number = 0_u8;
     let mut retried_after_forbidden_quota = false;
     loop {
-        let response = request()?;
+        let response = match request() {
+            Ok(response) => response,
+            Err(error)
+                if upstream_error_kind(&error) == Some("connect")
+                    && transport_retry_number < MAX_UPSTREAM_TRANSPORT_RETRIES =>
+            {
+                transport_retry_number = transport_retry_number.saturating_add(1);
+                let _ = wait_before_retry(upstream_transport_retry_delay(transport_retry_number));
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         if response.status == 429 {
             retry_number = retry_number.saturating_add(1);
             let elapsed = wait_before_retry(upstream_429_retry_delay(retry_number));
@@ -575,5 +590,13 @@ where
             continue;
         }
         return Ok(response);
+    }
+}
+
+fn upstream_transport_retry_delay(retry_number: u8) -> Duration {
+    match retry_number {
+        1 => Duration::from_millis(250),
+        2 => Duration::from_secs(1),
+        _ => Duration::ZERO,
     }
 }

--- a/apps/desktop/src-tauri/src/local_proxy/server.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/server.rs
@@ -207,8 +207,8 @@ fn handle_request<R: Runtime>(app: tauri::AppHandle<R>, mut request: Request) {
     let payload = match result {
         Ok(payload) => payload,
         Err(error) => json_payload(
-            upstream_error_status(&error),
-            json!({ "error": { "message": error } }),
+            error.status(),
+            json!({ "error": { "message": error.client_message() } }),
         ),
     };
     respond_payload(
@@ -256,7 +256,7 @@ fn handle_proxy_request<R: Runtime>(
     body: Vec<u8>,
     session_id: Option<&str>,
     session_request_id: Option<u64>,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     let path = request_path(url);
     let started_at = Instant::now();
     if *method == Method::Get && path == "/health" {
@@ -330,7 +330,7 @@ fn handle_proxy_request<R: Runtime>(
         return result;
     }
     if *method == Method::Get && matches!(path, "/usage" | "/v1/usage") {
-        return current_usage_payload(app);
+        return current_usage_payload(app).map_err(UpstreamError::from);
     }
     if *method == Method::Get && matches!(path, "/models" | "/v1/models") {
         let target = match active_target(app) {
@@ -344,7 +344,7 @@ fn handle_proxy_request<R: Runtime>(
                     None,
                     ProxyDiagnosticRoute::LocalModels,
                 );
-                let result = Err(error);
+                let result: UpstreamResult = Err(error.into());
                 append_proxy_diagnostic_result(app, diagnostic, &result, started_at.elapsed());
                 return result;
             }
@@ -360,6 +360,7 @@ fn handle_proxy_request<R: Runtime>(
         let retry_timeout = upstream_429_retry_timeout(app)?;
         let result = retry_upstream_request(
             retry_timeout,
+            upstream_transport_retry_mode(&target),
             || models_payload(app, url, headers, &target),
             |response, event| handle_upstream_quota_event(app, response, event),
         );
@@ -378,7 +379,7 @@ fn handle_proxy_request<R: Runtime>(
                 None,
                 ProxyDiagnosticRoute::TargetResolutionError,
             );
-            let result = Err(error);
+            let result: UpstreamResult = Err(error.into());
             append_proxy_diagnostic_result(app, diagnostic, &result, started_at.elapsed());
             return result;
         }
@@ -430,6 +431,7 @@ fn handle_proxy_request<R: Runtime>(
     let retry_timeout = upstream_429_retry_timeout(app)?;
     let result = retry_upstream_request(
         retry_timeout,
+        upstream_transport_retry_mode(&target),
         || forward_active_request(app, method, url, headers, body.clone(), &target, session_id),
         |response, event| handle_upstream_quota_event(app, response, event),
     );
@@ -457,7 +459,7 @@ fn forward_active_request<R: Runtime>(
     body: Vec<u8>,
     target: &ActiveTarget,
     session_id: Option<&str>,
-) -> Result<UpstreamPayload, String> {
+) -> UpstreamResult {
     match target {
         ActiveTarget::Official { model } => {
             if is_anthropic_messages_endpoint(request_path(url)) {
@@ -483,7 +485,9 @@ fn forward_active_request<R: Runtime>(
             target,
         }),
         ActiveTarget::ProviderGroup(_) => {
-            Err("Provider group requests must select a model".to_string())
+            Err(UpstreamError::Other(
+                "Provider group requests must select a model".to_string(),
+            ))
         }
     }
 }
@@ -531,28 +535,36 @@ fn upstream_429_retry_timeout<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<D
 
 fn retry_upstream_request<F, S>(
     timeout: Duration,
+    transport_retry_mode: UpstreamTransportRetryMode,
     request: F,
     handle_quota_event: S,
-) -> Result<UpstreamPayload, String>
+) -> UpstreamResult
 where
-    F: FnMut() -> Result<UpstreamPayload, String>,
+    F: FnMut() -> UpstreamResult,
     S: FnMut(&UpstreamPayload, UpstreamQuotaEvent) -> bool,
 {
     let started_at = Instant::now();
-    retry_upstream_request_with(timeout, request, handle_quota_event, |delay| {
-        thread::sleep(delay.min(timeout.saturating_sub(started_at.elapsed())));
-        started_at.elapsed()
-    })
+    retry_upstream_request_with(
+        timeout,
+        transport_retry_mode,
+        request,
+        handle_quota_event,
+        |delay| {
+            thread::sleep(delay.min(timeout.saturating_sub(started_at.elapsed())));
+            started_at.elapsed()
+        },
+    )
 }
 
 fn retry_upstream_request_with<F, S, W>(
     timeout: Duration,
+    transport_retry_mode: UpstreamTransportRetryMode,
     mut request: F,
     mut handle_quota_event: S,
     mut wait_before_retry: W,
-) -> Result<UpstreamPayload, String>
+) -> UpstreamResult
 where
-    F: FnMut() -> Result<UpstreamPayload, String>,
+    F: FnMut() -> UpstreamResult,
     S: FnMut(&UpstreamPayload, UpstreamQuotaEvent) -> bool,
     W: FnMut(Duration) -> Duration,
 {
@@ -563,11 +575,11 @@ where
         let response = match request() {
             Ok(response) => response,
             Err(error)
-                if upstream_error_kind(&error) == Some("connect")
+                if transport_retry_mode.should_retry(&error)
                     && transport_retry_number < MAX_UPSTREAM_TRANSPORT_RETRIES =>
             {
                 transport_retry_number = transport_retry_number.saturating_add(1);
-                let _ = wait_before_retry(upstream_transport_retry_delay(transport_retry_number));
+                wait_before_retry(upstream_transport_retry_delay(transport_retry_number));
                 continue;
             }
             Err(error) => return Err(error),
@@ -590,6 +602,15 @@ where
             continue;
         }
         return Ok(response);
+    }
+}
+
+fn upstream_transport_retry_mode(target: &ActiveTarget) -> UpstreamTransportRetryMode {
+    match target {
+        ActiveTarget::Official { .. } => UpstreamTransportRetryMode::OfficialConnectFailures,
+        ActiveTarget::Provider(_)
+        | ActiveTarget::ProviderGroup(_)
+        | ActiveTarget::Aggregate(_) => UpstreamTransportRetryMode::Disabled,
     }
 }
 

--- a/apps/desktop/src-tauri/src/local_proxy/tests/part_02.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/tests/part_02.rs
@@ -415,7 +415,8 @@
             |_, _| false,
             |_| Duration::from_secs(1),
         )
-        .unwrap_err();
+        .err()
+        .expect("connect retry exhaustion should return an error");
 
         assert!(error.contains("[connect]"));
         assert_eq!(request_count.load(AtomicOrdering::SeqCst), 3);

--- a/apps/desktop/src-tauri/src/local_proxy/tests/part_02.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/tests/part_02.rs
@@ -377,6 +377,51 @@
     }
 
     #[test]
+    fn transient_connect_errors_are_retried_with_bounded_backoff() {
+        let request_count = AtomicUsize::new(0);
+        let mut delays = Vec::new();
+        let response = retry_upstream_request_with(
+            Duration::from_secs(2),
+            || {
+                let attempt = request_count.fetch_add(1, AtomicOrdering::SeqCst);
+                if attempt < 2 {
+                    Err("Official Codex proxy request failed [connect]: connection refused".to_string())
+                } else {
+                    Ok(official_payload(200, 0))
+                }
+            },
+            |_, _| false,
+            |delay| {
+                delays.push(delay);
+                Duration::from_secs(1)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(response.status, 200);
+        assert_eq!(request_count.load(AtomicOrdering::SeqCst), 3);
+        assert_eq!(delays, [Duration::from_millis(250), Duration::from_secs(1)]);
+    }
+
+    #[test]
+    fn transport_retry_limit_returns_the_last_connect_error() {
+        let request_count = AtomicUsize::new(0);
+        let error = retry_upstream_request_with(
+            Duration::from_secs(2),
+            || {
+                request_count.fetch_add(1, AtomicOrdering::SeqCst);
+                Err("Official Codex proxy request failed [connect]: connection refused".to_string())
+            },
+            |_, _| false,
+            |_| Duration::from_secs(1),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("[connect]"));
+        assert_eq!(request_count.load(AtomicOrdering::SeqCst), 3);
+    }
+
+    #[test]
     fn final_429_selects_the_failed_account_for_automatic_disabling() {
         let response = official_payload(429, 0);
         let mut state = ManagerStateFile {

--- a/apps/desktop/src-tauri/src/local_proxy/tests/part_02.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/tests/part_02.rs
@@ -92,6 +92,7 @@
                 let mut attempt = 0;
                 retry_upstream_request_with(
                     Duration::from_secs(2),
+                    UpstreamTransportRetryMode::Disabled,
                     || {
                         let response = if attempt == 0 {
                             official_payload(429, observed_generation)
@@ -140,6 +141,7 @@
                 let mut attempt = 0;
                 retry_upstream_request_with(
                     Duration::from_secs(2),
+                    UpstreamTransportRetryMode::Disabled,
                     || {
                         let response = if attempt == 0 {
                             official_payload(429, observed_generation)
@@ -305,6 +307,7 @@
         let mut attempt = 0;
         let response = retry_upstream_request_with(
             Duration::from_secs(2),
+            UpstreamTransportRetryMode::Disabled,
             || {
                 let response = if attempt == 0 {
                     official_payload(429, observed_generation)
@@ -348,6 +351,7 @@
 
         let response = retry_upstream_request_with(
             Duration::from_secs(2),
+            UpstreamTransportRetryMode::Disabled,
             || {
                 request_count.fetch_add(1, AtomicOrdering::SeqCst);
                 Ok(official_payload(429, 0))
@@ -382,10 +386,15 @@
         let mut delays = Vec::new();
         let response = retry_upstream_request_with(
             Duration::from_secs(2),
+            UpstreamTransportRetryMode::OfficialConnectFailures,
             || {
                 let attempt = request_count.fetch_add(1, AtomicOrdering::SeqCst);
                 if attempt < 2 {
-                    Err("Official Codex proxy request failed [connect]: connection refused".to_string())
+                    Err(UpstreamError::transport(
+                        UpstreamTransportErrorKind::Connect,
+                        "Official Codex proxy request failed",
+                        "connection refused".to_string(),
+                    ))
                 } else {
                     Ok(official_payload(200, 0))
                 }
@@ -408,9 +417,14 @@
         let request_count = AtomicUsize::new(0);
         let error = retry_upstream_request_with(
             Duration::from_secs(2),
+            UpstreamTransportRetryMode::OfficialConnectFailures,
             || {
                 request_count.fetch_add(1, AtomicOrdering::SeqCst);
-                Err("Official Codex proxy request failed [connect]: connection refused".to_string())
+                Err(UpstreamError::transport(
+                    UpstreamTransportErrorKind::Connect,
+                    "Official Codex proxy request failed",
+                    "connection refused".to_string(),
+                ))
             },
             |_, _| false,
             |_| Duration::from_secs(1),
@@ -418,8 +432,38 @@
         .err()
         .expect("connect retry exhaustion should return an error");
 
-        assert!(error.contains("[connect]"));
+        assert!(error.is_connect());
+        assert_eq!(error.status(), 503);
         assert_eq!(request_count.load(AtomicOrdering::SeqCst), 3);
+    }
+
+    #[test]
+    fn provider_connect_errors_are_not_retried() {
+        let request_count = AtomicUsize::new(0);
+        let mut delays = Vec::new();
+        let error = retry_upstream_request_with(
+            Duration::from_secs(2),
+            UpstreamTransportRetryMode::Disabled,
+            || {
+                request_count.fetch_add(1, AtomicOrdering::SeqCst);
+                Err(UpstreamError::transport(
+                    UpstreamTransportErrorKind::Connect,
+                    "Provider proxy request failed",
+                    "connection refused".to_string(),
+                ))
+            },
+            |_, _| false,
+            |delay| {
+                delays.push(delay);
+                Duration::from_secs(1)
+            },
+        )
+        .err()
+        .expect("provider connection errors should be returned immediately");
+
+        assert!(error.is_connect());
+        assert_eq!(request_count.load(AtomicOrdering::SeqCst), 1);
+        assert!(delays.is_empty());
     }
 
     #[test]
@@ -452,6 +496,7 @@
         let mut elapsed = Duration::ZERO;
         let response = retry_upstream_request_with(
             Duration::from_secs(10),
+            UpstreamTransportRetryMode::Disabled,
             || {
                 let attempt = request_count.fetch_add(1, AtomicOrdering::SeqCst);
                 Ok(official_payload(if attempt < 3 { 429 } else { 200 }, 0))

--- a/apps/desktop/src-tauri/src/local_proxy/tests/part_03.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/tests/part_03.rs
@@ -227,21 +227,63 @@
 
     #[test]
     fn upstream_transport_errors_use_gateway_statuses() {
-        assert_eq!(
-            upstream_error_status("Official Codex proxy request failed [timeout]: timed out"),
-            504
+        let timeout = UpstreamError::transport(
+            UpstreamTransportErrorKind::Timeout,
+            "Official Codex proxy request failed",
+            "timed out".to_string(),
         );
-        assert_eq!(
-            upstream_error_status(
-                "Official Codex proxy request failed [connect]: connection refused"
-            ),
-            503
+        let connect = UpstreamError::transport(
+            UpstreamTransportErrorKind::Connect,
+            "Official Codex proxy request failed",
+            "connection refused".to_string(),
         );
-        assert_eq!(
-            upstream_error_status("Official Codex proxy request failed [request]: invalid request"),
-            502
+        let request = UpstreamError::transport(
+            UpstreamTransportErrorKind::Request,
+            "Official Codex proxy request failed",
+            "invalid request".to_string(),
         );
-        assert_eq!(upstream_error_status("an unrelated local error"), 502);
+
+        assert_eq!(timeout.status(), 504);
+        assert_eq!(connect.status(), 503);
+        assert_eq!(request.status(), 502);
+        assert_eq!(UpstreamError::Other("local error".to_string()).status(), 502);
+    }
+
+    #[test]
+    fn upstream_request_error_removes_sensitive_url_from_diagnostics_and_client_message() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let sensitive_url = format!(
+            "http://sensitive_user_4829:sensitive_password_7315@{address}/v1?token=sensitive_token_9137"
+        );
+        let error = Client::builder()
+            .no_proxy()
+            .connect_timeout(Duration::from_secs(1))
+            .build()
+            .unwrap()
+            .get(&sensitive_url)
+            .send()
+            .expect_err("the released loopback port should reject the connection");
+        assert!(error.url().is_some());
+
+        let error = upstream_request_error("Provider proxy request failed", error);
+        let diagnostic = error.diagnostic_message();
+        let client_message = error.client_message();
+
+        for secret in [
+            "sensitive_user_4829",
+            "sensitive_password_7315",
+            "sensitive_token_9137",
+        ] {
+            assert!(!diagnostic.contains(secret));
+            assert!(!client_message.contains(secret));
+        }
+        assert!(matches!(error.kind(), Some("connect" | "timeout")));
+        assert!(matches!(error.status(), 503 | 504));
+        assert!(client_message.starts_with("Provider proxy request failed: "));
+        assert!(!client_message.contains(&address.to_string()));
+        assert_ne!(diagnostic, client_message);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/local_proxy/tests/part_03.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/tests/part_03.rs
@@ -226,6 +226,43 @@
     }
 
     #[test]
+    fn upstream_transport_errors_use_gateway_statuses() {
+        assert_eq!(
+            upstream_error_status("Official Codex proxy request failed [timeout]: timed out"),
+            504
+        );
+        assert_eq!(
+            upstream_error_status(
+                "Official Codex proxy request failed [connect]: connection refused"
+            ),
+            503
+        );
+        assert_eq!(
+            upstream_error_status("Official Codex proxy request failed [request]: invalid request"),
+            502
+        );
+        assert_eq!(upstream_error_status("an unrelated local error"), 502);
+    }
+
+    #[test]
+    fn proxy_diagnostic_marks_image_input_without_logging_image_data() {
+        let body = br#"{"input":[{"type":"input_image","image_url":"data:image/png;base64,secret"}]}"#;
+        let entry = proxy_diagnostic_entry(
+            &Method::Post,
+            "/v1/responses",
+            &[],
+            body,
+            Some(&ActiveTarget::Official {
+                model: "gpt-5.6-sol".to_string(),
+            }),
+            ProxyDiagnosticRoute::Official,
+        );
+
+        assert_eq!(entry["containsInputImage"], true);
+        assert!(!entry.to_string().contains("data:image/png;base64,secret"));
+    }
+
+    #[test]
     fn proxy_diagnostic_entry_redacts_non_responses_body_content() {
         let provider = ProviderProfile {
             id: "chat".to_string(),

--- a/apps/desktop/src-tauri/src/local_proxy/tests/part_07.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/tests/part_07.rs
@@ -239,14 +239,14 @@
             json!({ "error": "busy" })
         ))));
         assert!(aggregate_result_is_retryable(&Err(
-            "Provider proxy request failed: connection reset".to_string()
+            UpstreamError::Other("Provider proxy request failed: connection reset".to_string())
         )));
         assert!(!aggregate_result_is_retryable(&Ok(json_payload(
             401,
             json!({ "error": "unauthorized" })
         ))));
         assert!(!aggregate_result_is_retryable(&Err(
-            "Request body is invalid".to_string()
+            UpstreamError::Other("Request body is invalid".to_string())
         )));
     }
 

--- a/apps/desktop/src-tauri/src/local_proxy/types.rs
+++ b/apps/desktop/src-tauri/src/local_proxy/types.rs
@@ -139,6 +139,145 @@ struct UpstreamPayload {
     token_usage_account: Option<TokenUsageAccount>,
 }
 
+type UpstreamResult = Result<UpstreamPayload, UpstreamError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpstreamTransportErrorKind {
+    Connect,
+    Timeout,
+    Request,
+    Other,
+}
+
+impl UpstreamTransportErrorKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Connect => "connect",
+            Self::Timeout => "timeout",
+            Self::Request => "request",
+            Self::Other => "other",
+        }
+    }
+
+    fn status(self) -> u16 {
+        match self {
+            Self::Connect => 503,
+            Self::Timeout => 504,
+            Self::Request | Self::Other => 502,
+        }
+    }
+
+    fn client_description(self) -> &'static str {
+        match self {
+            Self::Connect => "unable to connect to the upstream service",
+            Self::Timeout => "the upstream request timed out",
+            Self::Request => "the upstream request could not be sent",
+            Self::Other => "the upstream request failed",
+        }
+    }
+}
+
+#[derive(Debug)]
+enum UpstreamError {
+    Transport {
+        kind: UpstreamTransportErrorKind,
+        label: &'static str,
+        diagnostic_detail: String,
+    },
+    Other(String),
+}
+
+impl UpstreamError {
+    fn transport(
+        kind: UpstreamTransportErrorKind,
+        label: &'static str,
+        diagnostic_detail: String,
+    ) -> Self {
+        Self::Transport {
+            kind,
+            label,
+            diagnostic_detail,
+        }
+    }
+
+    fn status(&self) -> u16 {
+        match self {
+            Self::Transport { kind, .. } => kind.status(),
+            Self::Other(_) => 502,
+        }
+    }
+
+    fn kind(&self) -> Option<&'static str> {
+        match self {
+            Self::Transport { kind, .. } => Some(kind.as_str()),
+            Self::Other(_) => None,
+        }
+    }
+
+    fn client_message(&self) -> String {
+        match self {
+            Self::Transport { kind, label, .. } => {
+                format!("{label}: {}", kind.client_description())
+            }
+            Self::Other(message) => message.clone(),
+        }
+    }
+
+    fn diagnostic_message(&self) -> String {
+        match self {
+            Self::Transport {
+                kind,
+                label,
+                diagnostic_detail,
+            } => format!("{label} [{}]: {diagnostic_detail}", kind.as_str()),
+            Self::Other(message) => message.clone(),
+        }
+    }
+
+    fn is_connect(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport {
+                kind: UpstreamTransportErrorKind::Connect,
+                ..
+            }
+        )
+    }
+
+    fn is_aggregate_retryable(&self) -> bool {
+        match self {
+            Self::Transport { .. } => true,
+            Self::Other(message) => aggregate_error_message_is_retryable(message),
+        }
+    }
+}
+
+impl fmt::Display for UpstreamError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.client_message())
+    }
+}
+
+impl Error for UpstreamError {}
+
+impl From<String> for UpstreamError {
+    fn from(message: String) -> Self {
+        Self::Other(message)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UpstreamTransportRetryMode {
+    Disabled,
+    OfficialConnectFailures,
+}
+
+impl UpstreamTransportRetryMode {
+    fn should_retry(self, error: &UpstreamError) -> bool {
+        self == Self::OfficialConnectFailures && error.is_connect()
+    }
+}
+
 enum UpstreamBody {
     Buffered(Vec<u8>),
     Streaming(Box<dyn Read + Send>),

--- a/apps/desktop/src/api/backend.ts
+++ b/apps/desktop/src/api/backend.ts
@@ -2238,7 +2238,8 @@ export async function fetchSkillMarket(): Promise<SkillMarketItem[]> {
 }
 
 function selectedPackage(path: string, kind: SkillPackageSelection["kind"]): SkillPackageSelection {
-  const name = path.split(/[\\/]/).filter(Boolean).at(-1) ?? (kind === "folder" ? "skill-folder" : "skill.zip");
+  const pathSegments = path.split(/[\\/]/).filter(Boolean);
+  const name = pathSegments[pathSegments.length - 1] ?? (kind === "folder" ? "skill-folder" : "skill.zip");
   return { path, kind, name };
 }
 

--- a/apps/desktop/src/pages/codex-threads/utils.ts
+++ b/apps/desktop/src/pages/codex-threads/utils.ts
@@ -44,7 +44,8 @@ export function relativeTime(timestamp: number | null, language: Language) {
 
 export function groupLabel(cwd: string) {
   const normalized = cwd.replace(/\\/g, "/").replace(/\/$/, "");
-  return normalized.split("/").filter(Boolean).at(-1) || cwd;
+  const pathSegments = normalized.split("/").filter(Boolean);
+  return pathSegments[pathSegments.length - 1] || cwd;
 }
 
 export function isUnassignedWorkspace(cwd: string) {

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,7 +66,7 @@ For local Windows ARM64 app builds, install the Rust `aarch64-pc-windows-msvc` t
 - Tray issue: confirm `system_tray::refresh_menu` is called after account, usage, or active-account changes.
 - Floating bubble issue: inspect `settings.json`, window label `usage-bubble`, and the `theme-color-changed` event path.
 - Provider/config issue: inspect the managed blocks in `$CODEX_HOME/config.toml`, `config-before-provider.toml`, the selected Provider JSON, and the `providers-changed` event path. Never paste real Provider keys into an issue.
-- Local proxy issue: confirm `127.0.0.1:15722` is free, inspect `state.json`, call the local `/health` route, and export diagnostics from Settings. Review an export before sharing because upstream error details can still be sensitive.
+- Local proxy issue: confirm `127.0.0.1:15722` is free, inspect `state.json`, call the local `/health` route, and export diagnostics from Settings. Transport failures are classified as connection (`503`), timeout (`504`), or other gateway errors (`502`). Review an export before sharing because upstream error details can still be sensitive.
 - Token Usage issue: requests must pass through the local proxy. Inspect `token-usage.sqlite3`, the `token-usage` capability label, and the hash route used by the auxiliary window.
 - Cloud issue: verify the configured Base URL, Kong route split, backend logs, and `lastModifiedAt` values. Use only fake credentials while debugging synchronization.
 - Mobile issue: verify the same Base URL reaches `/auth/login` and `/sync/accounts/summary` from the device; localhost on the development computer is not localhost on a physical phone.


### PR DESCRIPTION
## 概要

- 对官方上游的瞬时连接失败执行最多两次有限退避重试
- 将连接失败、超时和其他传输失败分别映射为 503、504 和 502
- 使用类型化错误区分重试判断、客户端安全文案和内部诊断信息
- 在记录错误原因链前移除 Reqwest 请求 URL，避免泄露 Provider URL 中的用户信息或查询参数
- 普通 Provider、API 格式回退和聚合 Provider 不增加外层连接重试
- 复用已解析的请求 JSON 判断图片输入，避免大型 Base64 请求的重复解析
- 修复 ES2020 环境不支持 `Array.at()` 导致的桌面构建失败

## 重试范围

连接失败退避重试仅对 `Official` 路由启用，延迟依次为 250ms 和 1s。

Provider 路由仍立即返回传输错误；既有的 API 格式回退和聚合 Provider 成员切换行为保持不变。

## 验证

- `cargo fmt --all --check`
- `cargo clippy --offline --all-targets -- -D warnings`
- Rust 完整测试：436 通过、0 失败、3 忽略
- 本地代理专项测试：103 通过、0 失败
- 桌面 TypeScript/Vite 生产构建通过，仅有既存的大 chunk 警告
- `git diff --check` 通过
- 最新 `master` 变更与本分支无路径重叠